### PR TITLE
Coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -484,3 +484,4 @@ $RECYCLE.BIN/
 *.swp
 
 *.db
+coveragereport/

--- a/Backend/Backend.csproj
+++ b/Backend/Backend.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>

--- a/BackendTests/BackendTests.csproj
+++ b/BackendTests/BackendTests.csproj
@@ -20,4 +20,8 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Backend\Backend.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/BackendTests/UnitTest1.cs
+++ b/BackendTests/UnitTest1.cs
@@ -1,10 +1,16 @@
+using PSInzinerija1.Services;
+
 namespace BackendTests;
 
 public class UnitTest1
 {
     [Fact]
-    public void Test1()
+    public async Task GameRulesAPIService_ConstructorThrowsIfNullArgument()
     {
+        var gameRulesAPIService = new GameRulesAPIService(null);
 
+        var gameInfo = await gameRulesAPIService.GetGameRulesAsync();
+
+        Assert.Empty(gameInfo.Rules);
     }
 }

--- a/FrontendTests/FrontendTests.csproj
+++ b/FrontendTests/FrontendTests.csproj
@@ -20,4 +20,8 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Frontend\Frontend.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/PSInzinerija1.sln
+++ b/PSInzinerija1.sln
@@ -7,6 +7,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Frontend", "Frontend\Fronte
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Backend", "Backend\Backend.csproj", "{9366A09B-E539-4875-8B8D-14FF94DA9D2D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BackendTests", "BackendTests\BackendTests.csproj", "{0469F75F-2DD5-4FF2-A56B-E0549B8EADA3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FrontendTests", "FrontendTests\FrontendTests.csproj", "{CE5F990E-93C9-4407-8C85-DA06C8F2FCE7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shared", "Shared\Shared.csproj", "{3ACA3B08-BA0C-43F7-B254-43A05FB504DB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +27,18 @@ Global
 		{9366A09B-E539-4875-8B8D-14FF94DA9D2D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9366A09B-E539-4875-8B8D-14FF94DA9D2D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9366A09B-E539-4875-8B8D-14FF94DA9D2D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0469F75F-2DD5-4FF2-A56B-E0549B8EADA3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0469F75F-2DD5-4FF2-A56B-E0549B8EADA3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0469F75F-2DD5-4FF2-A56B-E0549B8EADA3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0469F75F-2DD5-4FF2-A56B-E0549B8EADA3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CE5F990E-93C9-4407-8C85-DA06C8F2FCE7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CE5F990E-93C9-4407-8C85-DA06C8F2FCE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CE5F990E-93C9-4407-8C85-DA06C8F2FCE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CE5F990E-93C9-4407-8C85-DA06C8F2FCE7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3ACA3B08-BA0C-43F7-B254-43A05FB504DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3ACA3B08-BA0C-43F7-B254-43A05FB504DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3ACA3B08-BA0C-43F7-B254-43A05FB504DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3ACA3B08-BA0C-43F7-B254-43A05FB504DB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/coverlet.runsettings.xml
+++ b/coverlet.runsettings.xml
@@ -1,0 +1,20 @@
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Exclude>
+            [*]*.Data*,
+            [*]*.Filters.*,
+            [Backend]*.Migrations*,
+            [*]Microsoft.AspNetCore*,
+            [Frontend]Frontend.Components*,
+            [Frontend]*.Extensions*,
+            [Frontend]*.Exceptions*
+          </Exclude>
+          <ExcludeByFile>**/Program.cs</ExcludeByFile>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/genreport.sh
+++ b/genreport.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Get the current directory name
+CURRENT_DIR_NAME=$(basename "$PWD")
+
+# Check if the current directory is "PSInzinerija"
+if [ "$CURRENT_DIR_NAME" != "PSInzinerija" ]; then
+    echo "Error: This script must be run from the 'PSInzinerija' directory!"
+    exit 1
+fi
+
+rm -r */TestResults/* coveragereport/*
+dotnet test --settings coverlet.runsettings.xml
+reportgenerator -reports:*/TestResults/*/coverage.cobertura.xml -targetdir:coveragereport


### PR DESCRIPTION
Reikalingas tool:
`dotnet tool install -g dotnet-reportgenerator-globaltool`

Coverage report generuojančio script'o paleidimas:
`bash genreport.sh`

Kaip atsidaryti:
1. Atsiranda `coveragereport` folderis
2. Jame yra index.html, kurį reikia atidaryti per browserį.

Pažiūrėkit ar generuojamas report'as apie visus failus, apie kuriuos turėtų būti. Mėginau išimti tuos, kurių maniau, kad nereikės, bet galimai išėmiau per daug.